### PR TITLE
POOL-792 Prize Page Errors

### DIFF
--- a/lib/components/AccountPoolRow.jsx
+++ b/lib/components/AccountPoolRow.jsx
@@ -95,7 +95,7 @@ export const AccountPoolRow = (
                 }}
                 values={{
                   amount: ethers.utils.formatUnits(
-                    pool?.prizeAmountUSD,
+                    pool?.totalPrizeAmountUSD,
                     decimals
                   )
                 }}

--- a/lib/components/AccountTicket.jsx
+++ b/lib/components/AccountTicket.jsx
@@ -168,9 +168,9 @@ export const AccountTicket = (
                   fontSansRegular
                   decimals={2}
                   duration={3}
-                  end={pool?.prizeAmountUSD ?
+                  end={pool?.grandPrizeAmountUSD ?
                     Math.floor(Number.parseFloat(
-                      ethers.utils.formatUnits(pool?.prizeAmountUSD, decimals)
+                      ethers.utils.formatUnits(pool?.grandPrizeAmountUSD, decimals)
                     )) : 
                     0
                   }

--- a/lib/components/IndexUI.jsx
+++ b/lib/components/IndexUI.jsx
@@ -22,7 +22,7 @@ export const IndexUI = (
     const decimals = _pool?.underlyingCollateralDecimals
 
     const cumulativePrizeAmountsForPool = normalizeTo18Decimals(
-      _pool.prizeAmountUSD,
+      _pool.totalPrizeAmountUSD,
       decimals
     )
 

--- a/lib/components/LastWinnersListing.jsx
+++ b/lib/components/LastWinnersListing.jsx
@@ -80,7 +80,7 @@ export const LastWinnersListing = (
               className='inline-block w-1/2 sm:w-1/2 text-right text-flashy'
             >
               ${displayAmountInEther(
-                pool?.prizeAmountUSD.toString(),
+                pool?.grandPrizeAmountUSD.toString(),
                 { decimals, precision: 2 }
               )}
             </span>
@@ -118,7 +118,7 @@ export const LastWinnersListing = (
                 {(timeTravelPool) => {
                   return <>
                     ${displayAmountInEther(
-                      timeTravelPool?.prizeAmountUSD.toString(),
+                      timeTravelPool?.grandPrizeAmountUSD.toString(),
                       { decimals, precision: 2 }
                     )}
                   </>

--- a/lib/components/PoolRowNew.jsx
+++ b/lib/components/PoolRowNew.jsx
@@ -75,7 +75,7 @@ export const PoolRowNew = (
             duration={6}
           >
             {ethers.utils.formatUnits(
-              pool?.prizeAmountUSD,
+              pool?.totalPrizeAmountUSD,
               decimals
             )}
           </PoolCountUp>

--- a/lib/components/PoolShow.jsx
+++ b/lib/components/PoolShow.jsx
@@ -114,9 +114,9 @@ export const PoolShow = (
   }
 
   let prizeEstimateFormatted
-  if (pool.prizeAmountUSD && pool.prizeAmountUSD.gt(0)) {
+  if (pool.totalPrizeAmountUSD && pool.totalPrizeAmountUSD.gt(0)) {
     prizeEstimateFormatted = ethers.utils.formatUnits(
-      pool.prizeAmountUSD,
+      pool.totalPrizeAmountUSD,
       decimals || DEFAULT_TOKEN_PRECISION
     )
   }

--- a/lib/components/PrizeAmount.jsx
+++ b/lib/components/PrizeAmount.jsx
@@ -38,7 +38,7 @@ export const PrizeAmount = (
         className='font-mono'
       >
         ${ethers.utils.formatUnits(
-          pool?.prizeAmountUSD,
+          pool?.grandPrizeAmountUSD,
           decimals
         )}
       </span>

--- a/lib/components/PrizeShow.jsx
+++ b/lib/components/PrizeShow.jsx
@@ -72,7 +72,7 @@ export function PrizeShow(props) {
       <div>
         <h1>
           ${displayAmountInEther(
-            pool?.prizeAmountUSD || 0,
+            pool?.totalPrizeAmountUSD || 0,
             { precision: 2, decimals }
           )}
         </h1>

--- a/lib/components/PrizeWinner.jsx
+++ b/lib/components/PrizeWinner.jsx
@@ -20,7 +20,7 @@ export const PrizeWinner = (
 
   const { chainId, pauseQueries } = useContext(AuthControllerContext)
 
-  const blockNumber = prize?.awardedBlock - 1
+  const blockNumber = prize?.awardedBlock
 
 
   let playerAddressError
@@ -44,6 +44,7 @@ export const PrizeWinner = (
     blockNumber,
     playerAddressError
   )
+
   const prizePoolAccount = data
 
   const decimals = pool?.underlyingCollateralDecimals || 18

--- a/lib/components/PrizesTable.jsx
+++ b/lib/components/PrizesTable.jsx
@@ -85,7 +85,7 @@ const formatPrizeObject = (t, pool, prize, querySymbol) => {
         {(timeTravelPool) => {
           return <>
             ${displayAmountInEther(
-              timeTravelPool?.prizeAmountUSD,
+              timeTravelPool?.grandPrizeAmountUSD,
               { decimals: pool?.underlyingCollateralDecimals, precision: 2 }
             )}
           </>
@@ -153,7 +153,7 @@ export const PrizesTable = (
     if (lastPrize.awardedBlock) {
       const currentPrizeId = extractPrizeNumberFromPrize(lastPrize) + 1
       const amount = ethers.utils.formatUnits(
-        pool?.prizeAmountUSD,
+        pool?.grandPrizeAmountUSD,
         decimals
       )
 

--- a/lib/services/compilePool.jsx
+++ b/lib/services/compilePool.jsx
@@ -54,8 +54,15 @@ export const compilePool = (
 
   const interestPrizeEstimateUSD = calculateEstimatedPoolPrize(poolObj)
 
+  
+  const numOfWinners = parseInt(poolObj.numberOfWinners || 1, 10)
+  const grandPrizeAmountUSD = externalAwardsEstimateUSD ?
+    interestPrizeEstimateUSD.div(numOfWinners).add(ethers.utils.parseEther(
+      externalAwardsEstimateUSD.toString()
+    )) :
+    interestPrizeEstimateUSD.div(numOfWinners)
 
-  const totalPrizeEstimateUSD = externalAwardsEstimateUSD ?
+  const totalPrizeAmountUSD = externalAwardsEstimateUSD ?
     interestPrizeEstimateUSD.add(ethers.utils.parseEther(
       externalAwardsEstimateUSD.toString()
     )) :
@@ -64,7 +71,8 @@ export const compilePool = (
   return {
     ...poolInfo,
     ...poolObj,
-    prizeAmountUSD: totalPrizeEstimateUSD,
+    totalPrizeAmountUSD,
+    grandPrizeAmountUSD,
     interestPrizeUSD: interestPrizeEstimateUSD,
     externalAwardsUSD: externalAwardsEstimateUSD,
     compiledExternalErc20Awards,

--- a/pages/prizes/[symbol]/[prizeNumber].jsx
+++ b/pages/prizes/[symbol]/[prizeNumber].jsx
@@ -38,7 +38,7 @@ export default function PrizeShowPage(props) {
   if (!prize?.awardedBlock) {
     prize = {
       awardedBlock: null,
-      net: pool?.prizeAmountUSD
+      net: pool?.grandPrizeAmountUSD
     }
 
     return <PrizeShow


### PR DESCRIPTION
There were a few inconsistencies with `interestPrizeUSD`. With historical prizes it's divided by number of winners, but the current pool is not, so it should be consistent now:

`interestPrizeUSD` is the total interest prize
`prizeAmountUSD` is now `grandPrizeAmountUSD`
`totalPrizeAmountUSD` is new

I've updated components accordingly to what I think they are meant to be but I could be wrong.