### PR TITLE
POOL-919 - Fix error when starting with mainnet and switching to rinkeby

### DIFF
--- a/lib/components/AccountGovernanceClaims.jsx
+++ b/lib/components/AccountGovernanceClaims.jsx
@@ -76,7 +76,7 @@ const ClaimHeader = props => {
   })
 
   return (
-    <div className='flex justify-between flex-col sm:flex-row mb-0 sm:mb-8 p-2 sm:p-0'>
+    <div className='flex justify-between flex-col sm:flex-row p-2 sm:p-0'>
       <div className='flex sm:flex-col justify-between sm:justify-start'>
         <h6 className='flex items-center font-normal'>{t('claimablePool')}</h6>
         <h2
@@ -93,7 +93,7 @@ const ClaimHeader = props => {
 
       <div className='flex flex-col-reverse sm:flex-col'>
         <ClaimAllButton refetch={refetch} claimable={totalClaimablePool > 0} />
-        <span className='sm:text-right text-accent-1 text-xxs mb-4 sm:mb-8'>
+        <span className='sm:text-right text-accent-1 text-xxs'>
           {t('whatCanIDoWithPool')}
         </span>
       </div>
@@ -241,7 +241,7 @@ const ClaimablePoolTokenItem = props => {
   const claimablePoolFormatted = numberWithCommas(claimablePoolNumber, { precision: getPrecision(claimablePoolNumber) })
 
   return (
-    <div className='bg-body p-6 rounded flex flex-col sm:flex-row sm:justify-between mb-4 sm:mb-8 last:mb-0'>
+    <div className='bg-body p-6 rounded flex flex-col sm:flex-row sm:justify-between mt-4 sm:mt-8'>
       <div className='flex flex-row-reverse sm:flex-row justify-between sm:justify-start mb-6 sm:mb-0'>
         <PoolCurrencyIcon
           

--- a/lib/components/NavPoolBalance.jsx
+++ b/lib/components/NavPoolBalance.jsx
@@ -54,6 +54,11 @@ const PoolBalanceModal = props => {
   const { data: retroactiveClaimablePool, isFetched: retroactiveClaimableIsFetched } = useRetroactivePoolClaimData()
 
   const claimablePoolIsLoaded = totalClaimableIsFetched && retroactiveClaimableIsFetched
+  
+  if (!claimablePoolIsLoaded) {
+    return null
+  }
+
   const totalPlusRetro = claimablePoolIsLoaded ? totalClaimablePool + retroactiveClaimablePool.formattedAmount : 0
   const totalClaimablePoolFormatted = numberWithCommas(totalPlusRetro, {
         precision: getPrecision(totalClaimablePool)

--- a/lib/hooks/useClaimablePool.js
+++ b/lib/hooks/useClaimablePool.js
@@ -12,6 +12,7 @@ import { usePool } from 'lib/hooks/usePool'
 import { testAddress } from 'lib/utils/testAddress'
 import ERC20Abi from 'abis/ERC20Abi'
 import { atom, useAtom } from 'jotai'
+import { useReadProvider } from 'lib/hooks/useReadProvider'
 
 export const claimablePoolRefetchFnsAtom = atom({})
 
@@ -49,9 +50,10 @@ export const useClaimablePool = poolSymbol => {
 }
 
 function useFetchClaimablePoolData (comptrollerAddress, poolAddress) {
-  const { usersAddress, chainId, pauseQueries, provider } = useContext(
+  const { usersAddress, chainId, pauseQueries } = useContext(
     AuthControllerContext
   )
+  const { readProvider, isLoaded: readProviderIsLoaded } = useReadProvider()
   const { accountData } = useAccount(usersAddress)
   const { playerTickets } = usePlayerTickets(accountData)
   const ticketData = playerTickets.find(
@@ -69,13 +71,14 @@ function useFetchClaimablePoolData (comptrollerAddress, poolAddress) {
     usersAddress &&
     !addressError &&
     comptrollerAddress &&
-    comptrollerAddress !== ethers.constants.AddressZero
+    comptrollerAddress !== ethers.constants.AddressZero &&
+    readProviderIsLoaded
 
   return useQuery(
-    [QUERY_KEYS.claimablePoolQuery, chainId, comptrollerAddress],
+    [QUERY_KEYS.claimablePoolQuery, chainId, comptrollerAddress, usersAddress],
     async () => {
       return getClaimablePoolData(
-        provider,
+        readProvider,
         usersAddress,
         comptrollerAddress,
         chainId

--- a/lib/hooks/useClaimablePoolComptrollerAddresses.js
+++ b/lib/hooks/useClaimablePoolComptrollerAddresses.js
@@ -8,10 +8,10 @@ import { usePlayerTickets } from "lib/hooks/usePlayerTickets"
 import { useContext } from "react"
 import { useQuery } from "react-query"
 import { ethers } from "ethers"
+import { useReadProvider } from "lib/hooks/useReadProvider"
 
 
 export const useClaimablePoolComptrollerAddresses = () => {
-
   const { usersAddress } = useContext(AuthControllerContext)
   const { accountData } = useAccount(usersAddress)
   const { playerTickets } = usePlayerTickets(accountData)
@@ -30,15 +30,16 @@ export const useClaimablePoolComptrollerAddresses = () => {
 }
 
 const useFetchPoolComptrollers = (poolAddresses) => {
-  const { pauseQueries, provider } = useContext(AuthControllerContext)
+  const { pauseQueries, chainId } = useContext(AuthControllerContext)
+  const { readProvider, isLoaded: readProviderIsLoaded } = useReadProvider()
 
   return useQuery(
-    [QUERY_KEYS.claimablePoolQuery],
+    [QUERY_KEYS.claimablePoolQuery, chainId, poolAddresses],
     async () => {
-      return getPoolComptrollers(provider, poolAddresses)
+      return getPoolComptrollers(readProvider, poolAddresses)
     },
     {
-      enabled: poolAddresses.length !== 0 && !pauseQueries,
+      enabled: poolAddresses.length !== 0 && !pauseQueries && readProviderIsLoaded,
       placeholderData: []
     }
   )

--- a/lib/hooks/usePoolTokenData.js
+++ b/lib/hooks/usePoolTokenData.js
@@ -5,20 +5,23 @@ import { CONTRACT_ADDRESSES, QUERY_KEYS } from 'lib/constants'
 import { useContext } from 'react'
 import { useQuery } from 'react-query'
 import { ethers } from 'ethers'
+import { useReadProvider } from 'lib/hooks/useReadProvider'
 
 export const usePoolTokenData = props => {
-  const { usersAddress, chainId, pauseQueries, provider } = useContext(
+  const { usersAddress, chainId, pauseQueries } = useContext(
     AuthControllerContext
   )
+  const { readProvider, isLoaded: readProviderIsLoaded } = useReadProvider()
+  
   return useQuery(
     [QUERY_KEYS.poolTokenDataQuery, chainId, usersAddress],
     async () => {
-      return getPoolTokenData(provider, chainId, usersAddress)
+      return getPoolTokenData(readProvider, chainId, usersAddress)
     },
     {
       // TODO: Remove chainId === 4
       enabled:
-        !pauseQueries && chainId && chainId === 4 && provider && usersAddress
+        !pauseQueries && chainId && chainId === 4 && readProviderIsLoaded && usersAddress
     }
   )
 }

--- a/lib/hooks/useReadProvider.jsx
+++ b/lib/hooks/useReadProvider.jsx
@@ -16,5 +16,5 @@ export function useReadProvider() {
     getReadProvider()
   }, [networkName])
     
-  return { readProvider: defaultReadProvider }
+  return { readProvider: defaultReadProvider, isLoaded: Object.keys(defaultReadProvider).length > 0 }
 }

--- a/lib/hooks/useRetroactivePoolClaimData.js
+++ b/lib/hooks/useRetroactivePoolClaimData.js
@@ -4,6 +4,7 @@ import { ethers } from 'ethers'
 import { axiosInstance } from 'lib/axiosInstance'
 import { AuthControllerContext } from 'lib/components/contextProviders/AuthControllerContextProvider'
 import { CONTRACT_ADDRESSES, QUERY_KEYS } from 'lib/constants'
+import { useReadProvider } from 'lib/hooks/useReadProvider'
 import { useContext } from 'react'
 import { useQuery } from 'react-query'
 
@@ -27,18 +28,19 @@ export const useRetroactivePoolClaimData = () => {
 }
 
 const useFetchRetroactivePoolClaimData = () => {
-  const { usersAddress, pauseQueries, provider, chainId } = useContext(
+  const { usersAddress, pauseQueries, chainId } = useContext(
     AuthControllerContext
   )
+  const { readProvider, isLoaded: readProviderIsLoaded } = useReadProvider()
 
   return useQuery(
     [QUERY_KEYS.retroactivePoolClaimDataQuery, usersAddress, chainId],
     async () => {
-      return getRetroactivePoolClaimData(provider, chainId, usersAddress)
+      return getRetroactivePoolClaimData(readProvider, chainId, usersAddress)
     },
     {
       // TODO: Remove chainId === 4
-      enabled: usersAddress && !pauseQueries && provider && chainId === 4,
+      enabled: usersAddress && !pauseQueries && readProviderIsLoaded && chainId === 4,
       refetchInterval: false
     }
   )

--- a/lib/hooks/useTotalClaimablePool.js
+++ b/lib/hooks/useTotalClaimablePool.js
@@ -9,12 +9,14 @@ import { batch, contract } from '@pooltogether/etherplex'
 import { ethers } from 'ethers'
 import { useAtom } from 'jotai'
 import { claimablePoolRefetchFnsAtom } from 'lib/hooks/useClaimablePool'
+import { useReadProvider } from 'lib/hooks/useReadProvider'
 
 export const useTotalClaimablePool = () => {
   const { data: comptrollerAddresses } = useClaimablePoolComptrollerAddresses()
-  const { usersAddress, pauseQueries, provider } = useContext(
+  const { usersAddress, pauseQueries, chainId } = useContext(
     AuthControllerContext
   )
+  const { readProvider, isLoaded: readProviderIsLoaded } = useReadProvider()
 
   const addressError = testAddress(usersAddress)
   const [claimablePoolRefetchFns, setClaimablePoolRefetchFns] = useAtom(
@@ -22,9 +24,9 @@ export const useTotalClaimablePool = () => {
   )
 
   const results = useQuery(
-    [QUERY_KEYS.claimablePoolQuery, comptrollerAddresses],
+    [QUERY_KEYS.claimablePoolQuery, comptrollerAddresses, usersAddress, chainId],
     async () => {
-      return getTotalClaimablePool(provider, usersAddress, comptrollerAddresses)
+      return getTotalClaimablePool(readProvider, usersAddress, comptrollerAddresses)
     },
     {
       enabled:
@@ -32,7 +34,8 @@ export const useTotalClaimablePool = () => {
         comptrollerAddresses.length > 0 &&
         !pauseQueries &&
         usersAddress &&
-        !addressError
+        !addressError && 
+        readProviderIsLoaded
     }
   )
 


### PR DESCRIPTION
- Using the `provider` from the auth context doesn't update (should have used the read provider anyways). So loading the page with mainnet connected, that variable created from the onboard init will always be mainnet. 
- There were a few issues with the query keys so they weren't updating properly when changing networks/connected accounts.
- Tiny margin fix for an empty list of `ClaimablePoolTokenItem`