### PR TITLE
Add Claim UI to Gov app

### DIFF
--- a/lib/components/RetroactivePoolClaimBanner.jsx
+++ b/lib/components/RetroactivePoolClaimBanner.jsx
@@ -1,5 +1,6 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useAtom } from 'jotai'
+import { useRouter } from 'next/router'
 
 import { AuthControllerContext } from 'lib/components/contextProviders/AuthControllerContextProvider'
 import { Banner } from 'lib/components/Banner'
@@ -12,12 +13,17 @@ import Bell from 'assets/images/bell@2x.png'
 
 export const RetroactivePoolClaimBanner = (props) => {
   const { t } = useTranslation()
+  const router = useRouter()
+  const claim = router.query.claim
+
   const [showClaimWizard, setShowClaimWizard] = useAtom(showClaimWizardAtom)
+  const [cachedUsersAddress, setCachedUsersAddress] = useState()
   const { chainId, usersAddress } = useContext(AuthControllerContext)
   const { data, loading } = useRetroactivePoolClaimData()
 
   useEffect(() => {
-    setShowClaimWizard(false)
+    setShowClaimWizard(claim && !cachedUsersAddress)
+    setCachedUsersAddress(usersAddress)
   }, [usersAddress])
 
   // TODO:  Remove. Temporary block on mainnet so nobody gets confused while testing.


### PR DESCRIPTION
I've added the same claim banner to the top of the Gov app only if you have tokens to claim, however if you press the "Claim" button all it does is redirect you to https://app.pooltogether.com

When the user lands on the flagship app's index with `claim=1` query var then show the claim modal, but only if we're moving from not having a wallet state to having a wallet state (ie. onboard boots up and pulls wallet from cookie)